### PR TITLE
dissabled markdown v2 stuff temporary

### DIFF
--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -237,6 +237,7 @@ class BotService:
                 chat_id,
                 f"Registro guardado correctamente\n\n"
                 f"{json.dumps(structured_data, indent=2)}\n\n"
+                # Avoid using Markdown formatting here to ensure compatibility with the message rendering system
                 f"ID de Transacción:\n{structured_data['transaction_id']}"
             )
 

--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -43,8 +43,7 @@ class BotService:
     async def _handle_unauthorized_access(self, update, context, message, chat_id, user_id):
         await context.bot.send_message(
             chat_id=chat_id,
-            text=f"Tu ID de usuario de Telegram es: `{user_id}`\nCompártelo con el administrador para que te dé acceso.",
-            parse_mode="Markdown"
+            text=f"Tu ID de usuario de Telegram es: {user_id}\nCompártelo con el administrador para que te dé acceso."
         )
         log_to_bigquery({
             "timestamp": datetime.now(self.cst).isoformat(),
@@ -69,7 +68,7 @@ class BotService:
             await safe_send_message(
                 context.bot,
                 chat_id,
-                f"✅ *ID de Transacción:*\n`{transaction_id}` eliminada correctamente."
+                f"✅ ID de Transacción:\n{transaction_id} eliminada correctamente."
             )
             log_to_bigquery({
                 "timestamp": datetime.now(self.cst).isoformat(),
@@ -122,7 +121,7 @@ class BotService:
             await safe_send_message(
                 context.bot,
                 chat_id,
-                f"✅ *ID de Transacción:*\n`{transaction_id}` actualizada correctamente."
+                f"✅ ID de Transacción:\n{transaction_id} actualizada correctamente."
             )
             log_to_bigquery({
                 "timestamp": datetime.now(self.cst).isoformat(),
@@ -237,8 +236,8 @@ class BotService:
                 context.bot,
                 chat_id,
                 f"Registro guardado correctamente\n\n"
-                f"```json\n{escape_user_text(json.dumps(structured_data, indent=2))}\n```"
-                f"\n\n🆔 *ID de Transacción:*\n`{structured_data['transaction_id']}`"
+                f"{json.dumps(structured_data, indent=2)}\n\n"
+                f"ID de Transacción:\n{structured_data['transaction_id']}"
             )
 
             config = load_bot_config()

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -7,11 +7,9 @@ def escape_user_text(text: str) -> str:
 
 
 async def safe_send_message(bot, chat_id: int, text: str, escape_user_input=False):
-    from telegram.constants import ParseMode
     if escape_user_input:
         text = escape_user_text(text)
     await bot.send_message(
         chat_id=chat_id,
-        text=text,
-        parse_mode=ParseMode.MARKDOWN_V2
+        text=text
     )


### PR DESCRIPTION
This pull request removes Markdown formatting from bot messages in the `services/bot_service.py` file and simplifies the `safe_send_message` function in `utils/helpers.py`. These changes aim to streamline message formatting and reduce reliance on specific parse modes.

### Changes to bot message formatting:
* Removed Markdown formatting (e.g., backticks and asterisks) from messages in `_handle_unauthorized_access`, `_handle_delete`, `_handle_edit`, and `_handle_data_insert` methods in `services/bot_service.py`. This ensures plain text is used for all bot messages. [[1]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L46-R46) [[2]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L72-R71) [[3]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L125-R124) [[4]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L240-R240)

### Changes to utility functions:
* Simplified the `safe_send_message` function in `utils/helpers.py` by removing the `parse_mode` parameter, making it compatible with plain text-only messages.