### PR TITLE
Edit command update

### DIFF
--- a/utils/bigquery_utils.py
+++ b/utils/bigquery_utils.py
@@ -86,7 +86,6 @@ class BigQueryUtils:
         self.safe_delete(transaction_id)
 
         new_data.setdefault("date", datetime.now(self.timezone).strftime("%Y-%m-%d"))
-        new_data["transaction_id"] = transaction_id
         new_data["operation"] = None
         new_data["is_deleted"] = False
         self.insert_to_bigquery(new_data)

--- a/utils/bigquery_utils.py
+++ b/utils/bigquery_utils.py
@@ -1,5 +1,5 @@
 from google.cloud import bigquery
-from datetime import datetime, timezone, timedelta
+from datetime import datetime
 import uuid
 import os
 


### PR DESCRIPTION
This pull request includes a minor update to the `safe_edit` method in `utils/bigquery_utils.py`. The change removes the explicit assignment of the `transaction_id` key in the `new_data` dictionary, likely because it is either redundant or handled elsewhere in the code. 

* [`utils/bigquery_utils.py`](diffhunk://#diff-54cf8b11cf5cdf33383010faeba55ce86f88f53360227605c0b66565d68b95f0L89): Removed the line `new_data["transaction_id"] = transaction_id` from the `safe_edit` method.