### PR TITLE
Enhance message formatting in BotService by adding MarkdownV2 support

### DIFF
--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -78,7 +78,13 @@ class BotService:
             await safe_send_message(
                 context.bot,
                 chat_id,
-                f"✅ ID de Transacción:\n{transaction_id} eliminada correctamente."
+                f"✅ ID de Transacción eliminada correctamente."
+            )
+            await safe_send_message(
+                context.bot,
+                chat_id,
+                f"`{transaction_id}`",
+                parse_mode="MarkdownV2"
             )
             self.bigquery_utils.log_to_bigquery({
                 "timestamp": datetime.now(self.timezone).isoformat(),
@@ -129,7 +135,13 @@ class BotService:
             await safe_send_message(
                 context.bot,
                 chat_id,
-                f"✅ ID de Transacción:\n{transaction_id} actualizada correctamente."
+                f"✅ ID de Transacción actualizada correctamente."
+            )
+            await safe_send_message(
+                context.bot,
+                chat_id,
+                f"`{transaction_id}`",
+                parse_mode="MarkdownV2"
             )
             self.bigquery_utils.log_to_bigquery({
                 "timestamp": datetime.now(self.timezone).isoformat(),
@@ -243,9 +255,16 @@ class BotService:
             await safe_send_message(
                 context.bot,
                 chat_id,
-                f"Registro guardado correctamente\n\n"
-                f"{json.dumps(structured_data, indent=2)}\n\n"
-                f"ID de Transacción:\n{structured_data['transaction_id']}"
+                f"Registro guardado correctamente."
+                f"{json.dumps(structured_data, indent=2)}",
+                f"✅ ID de Transacción guardada correctamente."
+
+            )
+            await safe_send_message(
+                context.bot,
+                chat_id,
+                f"`{structured_data['transaction_id']}`",
+                parse_mode="MarkdownV2"
             )
             try:
                 if self.config.get("liveNotifications"):

--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -255,10 +255,9 @@ class BotService:
             await safe_send_message(
                 context.bot,
                 chat_id,
-                f"Registro guardado correctamente."
-                f"{json.dumps(structured_data, indent=2)}",
+                f"Registro guardado correctamente.\n\n"
+                f"{json.dumps(structured_data, indent=2)}\n\n"
                 f"✅ ID de Transacción guardada correctamente."
-
             )
             await safe_send_message(
                 context.bot,

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,4 +1,5 @@
 import re
+from telegram.constants import ParseMode
 
 
 def escape_user_text(text: str) -> str:
@@ -6,10 +7,21 @@ def escape_user_text(text: str) -> str:
     return re.sub(f'([{re.escape(escape_chars)}])', r'\\\1', text)
 
 
-async def safe_send_message(bot, chat_id: int, text: str, escape_user_input=False):
+async def safe_send_message(bot, chat_id: int, text: str, escape_user_input=False, parse_mode=None):
+    """
+    Sends a message safely with optional MarkdownV2 formatting.
+
+    Args:
+        bot: The Telegram bot instance.
+        chat_id (int): The chat ID to send the message to.
+        text (str): The message text.
+        escape_user_input (bool): Whether to escape user input for MarkdownV2.
+        parse_mode (str): The parse mode for the message (e.g., "MarkdownV2").
+    """
     if escape_user_input:
         text = escape_user_text(text)
     await bot.send_message(
         chat_id=chat_id,
-        text=text
+        text=text,
+        parse_mode=parse_mode or ParseMode.HTML  # Default to HTML if no parse_mode is provided
     )


### PR DESCRIPTION
This pull request enhances message formatting in the `bot_service.py` file by introducing MarkdownV2 support for transaction IDs and refactoring the `safe_send_message` utility function to include an optional `parse_mode` parameter. These changes improve message readability and maintain consistency across the bot's communication.

### Enhancements to message formatting:

* `services/bot_service.py`:
  - Updated `_handle_delete`, `_handle_edit`, and `_handle_data_insert` methods to split transaction ID messages into two separate messages. The transaction ID is now sent as a second message with MarkdownV2 formatting for better emphasis. [[1]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L81-R87) [[2]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L132-R144) [[3]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L246-R267)

### Utility function improvements:

* `utils/helpers.py`:
  - Enhanced the `safe_send_message` function by adding a `parse_mode` parameter, allowing support for optional MarkdownV2 formatting. The default parse mode is set to HTML if none is provided.