### PR TITLE
Enhance Closure Report and message interpretation

### DIFF
--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -214,7 +214,11 @@ class BotService:
                         f"🔔 Notificación de administración:\n\n"
                         f"Operación realizada por {update.effective_user.full_name} (ID: {user_id})\n"
                         f"Acción: Cierre de caja\n"
-                        f"Fecha: {today}"
+                        f"Fecha: {today}\n\n"
+                        f"🏦 Ventas por transferencia bancaria: ${transfer_sales}\n"
+                        f"💵 Ventas en efectivo: ${efectivo_sales}\n"
+                        f"💰 Gastos del día: ${total_expenses}\n"
+                        f"💵 Total efectivo en caja: ${efectivo_sales - total_expenses}\n\n"
                     )
             except Exception as notify_error:
                 print(f"Error notificando al Owner: {notify_error}")

--- a/utils/gpt_utils.py
+++ b/utils/gpt_utils.py
@@ -37,6 +37,7 @@ def interpret_message_with_gpt(message: str, config) -> str:
                     "- If the message describes a **sale** (e.g., 'vendimos', 'se vendió'), create an entry under \"sales\" and set \"total_sale_price\".\n"
                     "- If the message describes only an expense, \"total_sale_price\" must be null.\n"
                     "- If no payment method is mentioned and it is not a sale, set \"payment_method\" to null.\n"
+                    "- If the message contains "docena" take it as 12 units. but dont calculate the price for total_sale_price, just leave what the user passed\n"
                     "- Always output only valid JSON without additional explanations."
                 )
             },

--- a/utils/gpt_utils.py
+++ b/utils/gpt_utils.py
@@ -37,7 +37,7 @@ def interpret_message_with_gpt(message: str, config) -> str:
                     "- If the message describes a **sale** (e.g., 'vendimos', 'se vendió'), create an entry under \"sales\" and set \"total_sale_price\".\n"
                     "- If the message describes only an expense, \"total_sale_price\" must be null.\n"
                     "- If no payment method is mentioned and it is not a sale, set \"payment_method\" to null.\n"
-                    "- If the message contains "docena" take it as 12 units. but dont calculate the price for total_sale_price, just leave what the user passed\n"
+                    "- If the message contains \"docena\" take it as 12 units, but don't calculate the price for total_sale_price; just leave what the user passed.\n"
                     "- Always output only valid JSON without additional explanations."
                 )
             },


### PR DESCRIPTION
This pull request introduces enhancements to the bot's reporting functionality and updates the GPT message interpretation logic. The key changes include providing more detailed financial breakdowns in the closure report and refining the handling of specific terms in sales-related messages.

### Reporting Enhancements:
* [`services/bot_service.py`](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L217-R221): Updated the `_handle_closure_report` method to include additional financial details in the closure report, such as sales by transfer, cash sales, daily expenses, and total cash in hand.

### Message Interpretation Improvements:
* [`utils/gpt_utils.py`](diffhunk://#diff-0596e2f342dac44d78a380442d5c1101f5239823a07f4d5145f6b97b69e22317R40): Enhanced the `interpret_message_with_gpt` function to recognize the term "docena" as 12 units without altering the user-provided price for `total_sale_price`.