### PR TITLE
fix data insert command

### DIFF
--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -259,6 +259,9 @@ class BotService:
                 )
                 return
 
+            structured_data.setdefault("date", datetime.now(self.timezone).strftime("%Y-%m-%d"))
+            self.bigquery_utils.insert_to_bigquery(structured_data)
+
             if structured_data.get("sales"):
                 inventory_issues = self.inventory_manager.deduct_inventory(
                     structured_data["sales"], structured_data["transaction_id"]
@@ -269,9 +272,7 @@ class BotService:
                         text="⚠️ Problemas con el inventario:\n" +
                              "\n".join([f"- {issue['item']} ({issue['quality']}): {issue['reason']}" for issue in inventory_issues])
                     )
-
-            structured_data.setdefault("date", datetime.now(self.timezone).strftime("%Y-%m-%d"))
-            self.bigquery_utils.insert_to_bigquery(structured_data)
+  
             user_name = structured_data.get("sender_name", update.effective_user.full_name)
             self.bigquery_utils.log_to_bigquery({
                 "timestamp": datetime.now(self.timezone).isoformat(),

--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -259,8 +259,22 @@ class BotService:
                 )
                 return
 
+            # Set the date and insert data into BigQuery before inventory deductions
+            # to ensure an audit trail is preserved even if inventory operations fail.
             structured_data.setdefault("date", datetime.now(self.timezone).strftime("%Y-%m-%d"))
-            self.bigquery_utils.insert_to_bigquery(structured_data)
+            try:
+                self.bigquery_utils.insert_to_bigquery(structured_data)
+            except Exception as insert_error:
+                await self._notify_error(
+                    context.bot,
+                    chat_id,
+                    self.developer_id,
+                    update.effective_user.full_name,
+                    user_id,
+                    "insertar",
+                    f"Error al insertar en BigQuery: {insert_error}"
+                )
+                return
 
             if structured_data.get("sales"):
                 inventory_issues = self.inventory_manager.deduct_inventory(


### PR DESCRIPTION
This pull request modifies the `_handle_data_insert` method in `services/bot_service.py` to adjust the sequence of operations for inserting structured data into BigQuery and handling inventory deductions. The changes ensure that inventory issues are addressed before data is logged.

### Changes to operation sequence:

* Moved the `structured_data.setdefault("date", ...)` and `self.bigquery_utils.insert_to_bigquery(structured_data)` calls to occur before inventory deductions. This ensures that data is inserted into BigQuery prior to any potential inventory-related operations. [[1]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66R262-R264) [[2]](diffhunk://#diff-fc0a57db0acab6f429b7b36e897b3365a2c8dad7dffecff333f1fd8a075ced66L273-L274)