### PR TITLE
Fix transaction ID reference

### DIFF
--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -146,7 +146,7 @@ class BotService:
             await safe_send_message(
                 context.bot,
                 chat_id,
-                f"`{transaction_id}`",
+                f"`{new_data["transaction_id"]}`",
                 parse_mode="MarkdownV2"
             )
             self.bigquery_utils.log_to_bigquery({
@@ -165,7 +165,7 @@ class BotService:
                         f"🔔 Notificación de administración:\n\n"
                         f"Operación realizada por {user_name} (ID: {user_id})\n"
                         f"Acción: Editar\n"
-                        f"ID de Transacción: {transaction_id}"
+                        f"ID de Transacción: {new_data["transaction_id"]}"
                     )
             except Exception as notify_error:
                 print(f"Error notificando al Owner: {notify_error}")

--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -146,7 +146,7 @@ class BotService:
             await safe_send_message(
                 context.bot,
                 chat_id,
-                f"`{new_data["transaction_id"]}`",
+                f"`{new_data['transaction_id']}`",
                 parse_mode="MarkdownV2"
             )
             self.bigquery_utils.log_to_bigquery({
@@ -165,7 +165,7 @@ class BotService:
                         f"🔔 Notificación de administración:\n\n"
                         f"Operación realizada por {user_name} (ID: {user_id})\n"
                         f"Acción: Editar\n"
-                        f"ID de Transacción: {new_data["transaction_id"]}"
+                        f"ID de Transacción: {new_data['transaction_id']}"
                     )
             except Exception as notify_error:
                 print(f"Error notificando al Owner: {notify_error}")


### PR DESCRIPTION
This pull request updates the `services/bot_service.py` file to ensure the correct transaction ID is used in messages and notifications by replacing `transaction_id` with `new_data["transaction_id"]`.

Key changes:

### Bug Fixes:
* Updated the transaction ID in the message sent via `safe_send_message` to use `new_data["transaction_id"]` instead of the outdated `transaction_id`.
* Updated the transaction ID in the administration notification to use `new_data["transaction_id"]` for consistency and accuracy.