### PR TITLE
fix query for transaction retreival

### DIFF
--- a/utils/bigquery_utils.py
+++ b/utils/bigquery_utils.py
@@ -140,8 +140,6 @@ class BigQueryUtils:
         SELECT *
         FROM `{table_id}`
         WHERE transaction_id = @transaction_id
-          AND operation IS NULL
-          AND is_deleted = FALSE
         """
         job_config = bigquery.QueryJobConfig(
             query_parameters=[


### PR DESCRIPTION
This pull request makes a small but significant change to the `get_transaction_by_id` method in `utils/bigquery_utils.py`. The change removes two filtering conditions (`operation IS NULL` and `is_deleted = FALSE`) from the SQL query. 

* [`utils/bigquery_utils.py`](diffhunk://#diff-54cf8b11cf5cdf33383010faeba55ce86f88f53360227605c0b66565d68b95f0L143-L144): Removed the `operation IS NULL` and `is_deleted = FALSE` conditions from the SQL query in the `get_transaction_by_id` method, potentially broadening the scope of returned transactions.