### PR TITLE
Implement duplicate update handling in FirestoreLoader and main function

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,11 +39,11 @@ async def main(request):
         update = Update.de_json(request.json, app.bot)
         update_id = update.update_id
 
-        if firestore_loader.is_duplicate_update(update_id):
+        if await asyncio.to_thread(firestore_loader.is_duplicate_update, update_id):
             print(f"Duplicate update received: {update_id}")
             return "ok"
 
-        firestore_loader.mark_update_processed(update_id)
+        await asyncio.to_thread(firestore_loader.mark_update_processed, update_id)
         await app.process_update(update)
 
     return "ok"

--- a/main.py
+++ b/main.py
@@ -37,6 +37,13 @@ async def main(request):
 
     async with app:
         update = Update.de_json(request.json, app.bot)
+        update_id = update.update_id
+
+        if firestore_loader.is_duplicate_update(update_id):
+            print(f"Duplicate update received: {update_id}")
+            return "ok"
+
+        firestore_loader.mark_update_processed(update_id)
         await app.process_update(update)
 
     return "ok"


### PR DESCRIPTION
This pull request introduces functionality to handle duplicate Telegram updates and ensures updates are marked as processed in Firestore. Additionally, it adds timezone support for consistent timestamp formatting. The most important changes include adding methods for duplicate update detection and processing in `FirestoreLoader`, integrating these methods into the main application flow, and introducing timezone handling.

### Duplicate update handling:

* [`config/loader.py`](diffhunk://#diff-4dd261800b9590a969637edfdbd695d93f81e13be2dd973f703ce28a26297a45R66-R76): Added `is_duplicate_update` and `mark_update_processed` methods to check for duplicate Telegram updates and mark updates as processed in Firestore. These methods utilize the new `current_cst_iso` method for consistent timestamp formatting.
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R40-R46): Integrated duplicate update handling by checking for duplicates using `is_duplicate_update`, logging duplicate updates, and marking updates as processed using `mark_update_processed`.

### Timezone support:

* [`config/loader.py`](diffhunk://#diff-4dd261800b9590a969637edfdbd695d93f81e13be2dd973f703ce28a26297a45R2-R3): Imported `pytz` and added a `timezone` attribute initialized to "America/El_Salvador". This is used in the `current_cst_iso` method to format timestamps in the specified timezone. [[1]](diffhunk://#diff-4dd261800b9590a969637edfdbd695d93f81e13be2dd973f703ce28a26297a45R2-R3) [[2]](diffhunk://#diff-4dd261800b9590a969637edfdbd695d93f81e13be2dd973f703ce28a26297a45R16-R17)